### PR TITLE
no async

### DIFF
--- a/library.cpp
+++ b/library.cpp
@@ -5,6 +5,7 @@
 #include <boost/regex.hpp>
 #include <iomanip>
 #include <iostream>
+#include <map>
 
 namespace net       = boost::asio;          // from <boost/asio.hpp>
 namespace beast     = boost::beast;         // from <boost/beast.hpp>
@@ -14,45 +15,75 @@ using tcp           = boost::asio::ip::tcp; // from <boost/asio/ip/tcp.hpp>
 using namespace std::chrono_literals;
 
 #define TRACE(stream, msg) do { stream << L"<WsDll-" ARCH_LABEL L"> " << msg << std::endl; } while(0)
-#define VERBOSE(msg) do { if (s_enable_verbose) { TRACE(std::wcout, msg); } } while(0)
+#define VERBOSE(msg) do { if (g_enable_verbose) { TRACE(std::wcout, msg); } } while(0)
 #define COUT(msg) TRACE(std::wcout, msg)
 #define CERR(msg) TRACE(std::wcerr, msg)
 
 namespace /*anon*/ {
-    static on_fail_t       s_on_fail_cb{nullptr};
-    static on_disconnect_t s_on_disconnect_cb{nullptr};
-    static on_data_t       s_on_data_cb{nullptr};
-
     // Global variables
-    static std::atomic_bool s_enable_verbose{false};
+    static std::atomic_bool g_enable_verbose{false};
+    static net::thread_pool g_thread_pool;
 
     class Session;
     using SessionPtr = std::shared_ptr<Session>;
+    using Handle     = size_t;
 
     struct Manager {
-        // TODO maybe allow multiple sessions and use weak pointers instead?
-        static inline SessionPtr Install(SessionPtr sess)
+
+        inline Handle Register(SessionPtr const& sess)
         {
-            std::shared_ptr<Session> no_session{};
-            if (!std::atomic_compare_exchange_strong(&s_instance_unsafe, &no_session, sess)) {
-                return nullptr;
+            std::lock_guard lk(mx_);
+
+            garbage_collect();
+            assert(sess);
+
+            Handle handle = next_handle_++;
+            auto [it, ok] = sessions_.emplace(handle, sess);
+            assert(ok);
+
+            return handle;
+        }
+
+        inline bool Forget(Handle h)
+        {
+            std::lock_guard lk(mx_);
+
+            garbage_collect();
+
+            if (auto it = sessions_.find(h); it != end(sessions_)) {
+                sessions_.erase(it);
+                return true;
             }
-            return sess;
+
+            return false;
         }
 
-        static inline SessionPtr Active() {
-            return std::atomic_load(&s_instance_unsafe);
-        }
-
-        static inline bool Clear(SessionPtr sess)
+        inline SessionPtr Active(Handle h)
         {
-            return std::atomic_compare_exchange_strong(&s_instance_unsafe, &sess, {});
+            std::lock_guard lk(mx_);
+
+            if (auto it = sessions_.find(h); it != end(sessions_))
+                return it->second.lock();
+
+            return nullptr;
         }
 
       private:
-        static SessionPtr s_instance_unsafe; // use atomic_ operations to safely access
-    };
-    /*static*/ SessionPtr Manager::s_instance_unsafe;
+        using Registry = std::map<Handle, std::weak_ptr<Session>>;
+        std::mutex mx_;
+        size_t     next_handle_ = 1;
+        Registry   sessions_;
+
+        void garbage_collect() // lock must be held
+        {
+            for (auto it = begin(sessions_); it != end(sessions_);) {
+                if (it->second.expired())
+                    it = sessions_.erase(it);
+                else
+                    ++it;
+            }
+        }
+    } g_session_manager;
 
     std::string utf8_encode(std::wstring const& wstr)
     {
@@ -110,12 +141,11 @@ namespace /*anon*/ {
     }
 
     class Session : public std::enable_shared_from_this<Session> {
-        net::thread_pool                     ioc_{1};
-        websocket::stream<beast::tcp_stream> ws_{make_strand(ioc_.get_executor())};
+        websocket::stream<beast::tcp_stream> ws_{make_strand(g_thread_pool)};
         tcp::resolver                        resolver_{ws_.get_executor()};
 
         beast::flat_buffer buffer_;
-        std::wstring       host_, path_; // path part in url. For example: /v2/ws
+        std::wstring       host_, port_, path_; // path part in url. For example: /v2/ws
 
         /// Print error related information in stderr
         /// \param ec instance that contains error related information
@@ -130,147 +160,170 @@ namespace /*anon*/ {
                 VERBOSE(msg);
             }
             else {
-                if (s_on_fail_cb)
-                    s_on_fail_cb(msg.c_str());
+                if (on_fail_cb)
+                    on_fail_cb(handle_, msg.c_str());
                 CERR(msg);
             }
         }
 
+#include <boost/asio/yield.hpp>
+        struct connect_op {
+            using EC  = beast::error_code;
+            using EP  = tcp::endpoint;
+            using EPS = tcp::resolver::results_type;
+            template <typename Self> void operator()(Self& self, EC ec, EPS r) { return call(self, ec, r); }
+            template <typename Self> void operator()(Self& self, EC ec, EP) { return call(self, ec); }
+            template <typename Self> void operator()(Self& self, EC ec) { return call(self, ec); }
+            template <typename Self> void operator()(Self& self) { return call(self); }
+
+            SessionPtr     s;
+            net::coroutine coro;
+
+          private:
+            template <typename Self>
+            void call(Self& self, beast::error_code ec = {}, tcp::resolver::results_type results = {})
+            {
+                auto& ws_ = s->ws_;
+                reenter(coro)
+                {
+                    yield s->resolver_.async_resolve(utf8_encode(s->host_), utf8_encode(s->port_),
+                                                     std::move(self));
+                    if (ec) goto complete;
+
+                    beast::get_lowest_layer(ws_).expires_after(30s);
+                    yield beast::get_lowest_layer(ws_).async_connect(results, std::move(self));
+                    if (ec) goto complete;
+
+                    beast::get_lowest_layer(ws_).expires_never();
+                    ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
+                    ws_.set_option(websocket::stream_base::decorator([](websocket::request_type& req) {
+                        req.set(http::field::user_agent, std::string(BOOST_BEAST_VERSION_STRING) + " WsDll");
+                    }));
+
+                    // Host HTTP header includes the port. See https://tools.ietf.org/html/rfc7230#section-5.4
+                    yield ws_.async_handshake(utf8_encode(s->host_) + ":" + utf8_encode(s->port_),
+                                              utf8_encode(s->path_), std::move(self));
+
+complete:
+                    s.reset(); // deallocate before completion
+                    return self.complete(ec);
+                }
+            }
+        };
+#include <boost/asio/yield.hpp>
+
+        template<typename Token>
+        auto async_connect(Token&& token) {
+            return net::async_compose<Token, void(beast::error_code)>(connect_op{shared_from_this(), {}},
+                                                                      token);
+        }
+
       public:
+        Handle          handle_          = 0; // TODO make friend/private?
+        on_fail_t       on_fail_cb       = nullptr;
+        on_disconnect_t on_disconnect_cb = nullptr;
+        on_data_t       on_data_cb       = nullptr;
+
         Session() = default;
+        ~Session()
+        {
+            try {
+                if (on_disconnect_cb)
+                    std::exchange(on_disconnect_cb, nullptr)(handle_);
+            }
+            catch (std::exception const& e) {
+                // swallow
+            }
+        }
+
+        /// Start asynchronous operation
+        ///
+        /// Only returns when connection (attempt) completed
+        int run(std::wstring host, std::wstring port, std::wstring path)
+        {
+            // Save these for later
+            host_ = std::move(host);
+            port_ = std::move(port);
+            path_ = std::move(path);
+
+            VERBOSE(L"Run host_: " << host_ << L", port: " << port_ << L", path_: " << path_);
+            try {
+                assert(shared_from_this());
+                async_connect(net::use_future).get();
+
+                VERBOSE(L"Issue async_read after connect");
+                ws_.async_read(buffer_, beast::bind_front_handler(&Session::on_read, shared_from_this()));
+                return 1;
+            }
+            catch (beast::system_error const& se) {
+                fail(se.code(), L"Connection operation");
+                return 0;
+            }
+        }
 
         /// Send message to remote websocket server
         /// \param data to be sent
-        void send_message(std::wstring const& data)
+        bool send_message(std::wstring const& data)
         {
-            post(ws_.get_executor(),
-                 std::bind(&Session::do_send_message, shared_from_this(), utf8_encode(data)));
+            std::promise<void> p;
+            auto fut = p.get_future();
+
+            try {
+                VERBOSE(L"Writing message: " << data);
+                post(ws_.get_executor(), [this, &p, udata = utf8_encode(data)]() mutable {
+                    ws_.async_write( //
+                        net::buffer(udata), [&p](beast::error_code ec, size_t) mutable {
+                            if (!ec)
+                                p.set_value();
+                            else {
+                                p.set_exception(std::make_exception_ptr(beast::system_error(ec)));
+                            }
+                        });
+                });
+                fut.get();
+                return true;
+            }
+            catch (beast::system_error const& se) {
+                fail(se.code(), L"send_message");
+                return false;
+            }
         }
 
         /// Close the connect between websocket client and server. It call
         /// async_close to call a callback function which also calls user
         /// registered callback function to deal with close event.
-        void disconnect()
+        bool disconnect()
         {
-            post(ws_.get_executor(), std::bind(&Session::do_disconnect, shared_from_this()));
+            std::promise<void> p;
+            auto fut = p.get_future();
+
+            try {
+                post(ws_.get_executor(), [this, &p]() mutable {
+                    VERBOSE(L"Disconnecting");
+                    ws_.async_close( //
+                        websocket::close_code::normal, [&p](beast::error_code ec) mutable {
+                            if (!ec)
+                                p.set_value();
+                            else {
+                                p.set_exception(std::make_exception_ptr(beast::system_error(ec)));
+                            }
+                        });
+                });
+                fut.get();
+
+                if (on_disconnect_cb)
+                    std::exchange(on_disconnect_cb, nullptr)(handle_);
+
+                return g_session_manager.Forget(handle_);
+            }
+            catch (beast::system_error const& se) {
+                fail(se.code(), L"disconnect");
+                return false;
+            }
         }
 
-        /// Start the asynchronous operation
-        /// \param host host to be connected
-        /// \param port tcp port to be connected
-        void run(std::wstring host, std::wstring port, std::wstring path)
-        {
-            // Save these for later
-            host_ = std::move(host);
-            path_ = std::move(path);
-
-            VERBOSE(L"Run host_: " << host_ << L", port: " << port << L", path_: " << path_);
-
-            // Look up the domain name
-            resolver_.async_resolve(utf8_encode(host_), utf8_encode(port),
-                                    beast::bind_front_handler(&Session::on_resolve, shared_from_this()));
-            }
 
       private: // all private (do_*/on_*) assumed on strand
-        std::deque<std::string> _outbox; // NOTE: reference stability of elements
-
-        void do_send_message(std::string data)
-        {
-            VERBOSE(L"Queueing message: " << quoted(utf8_decode(data)));
-            _outbox.push_back(std::move(data)); // extend lifetime to completion of async write
-
-            if (_outbox.size()==1) // need to start write chain?
-                do_write_loop();
-        }
-
-        void do_disconnect()
-            {
-            VERBOSE(L"Disconnecting");
-            ws_.async_close(websocket::close_code::normal,
-                            beast::bind_front_handler(&Session::on_close, shared_from_this()));
-            }
-
-        /// Callback function registered by async_resolve method. It is
-        /// called after resolve operation is done. It will call
-        /// async_connect to issue async connecting operation with
-        /// callback function
-        /// \param ec
-        /// \param results
-        void on_resolve(beast::error_code ec, tcp::resolver::results_type const& results)
-        {
-            VERBOSE(L"In on_resolve");
-            if (ec)
-                return fail(ec, L"resolve");
-
-            // Set the timeout for the operation
-            beast::get_lowest_layer(ws_).expires_after(30s);
-
-            // Make the connection on the IP address we get from a lookup
-            beast::get_lowest_layer(ws_).async_connect(
-                results, beast::bind_front_handler(&Session::on_connect, shared_from_this()));
-        }
-
-        void on_connect(beast::error_code ec, tcp::resolver::results_type::endpoint_type ep)
-        {
-            VERBOSE(L"In on_connect");
-            if (ec)
-                return fail(ec, L"connect");
-
-            // Turn off the timeout on the tcp_stream, because
-            // the websocket stream has its own timeout system.
-            beast::get_lowest_layer(ws_).expires_never();
-
-            // Set suggested timeout settings for the websocket
-            ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
-
-            // Set a decorator to change the User-Agent of the handshake
-            ws_.set_option(websocket::stream_base::decorator([](websocket::request_type& req) {
-                req.set(http::field::user_agent,
-                        std::string(BOOST_BEAST_VERSION_STRING) + " WsDll");
-            }));
-
-            // Perform the websocket handshake
-
-            // Host HTTP header includes the port. See https://tools.ietf.org/html/rfc7230#section-5.4
-            ws_.async_handshake(utf8_encode(host_) + ":" + std::to_string(ep.port()), utf8_encode(path_),
-                                beast::bind_front_handler(&Session::on_handshake, shared_from_this()));
-        }
-
-        void on_handshake(beast::error_code ec)
-        {
-            VERBOSE(L"In on_handshake");
-            if (ec)
-                return fail(ec, L"handshake");
-
-            // Send the message
-            VERBOSE(L"Issue async_read in on_handshake");
-            ws_.async_read(buffer_, beast::bind_front_handler(&Session::on_read, shared_from_this()));
-        }
-
-        void do_write_loop()
-        {
-            if (_outbox.empty()) {
-                VERBOSE(L"Output queue empty");
-                return;
-            }
-
-            VERBOSE(L"Writing message: " << quoted(utf8_decode(_outbox.front())));
-            ws_.async_write(net::buffer(_outbox.front()),
-                            beast::bind_front_handler(&Session::on_write, shared_from_this()));
-        }
-
-        void on_write(beast::error_code ec, std::size_t bytes_transferred)
-        {
-            VERBOSE(L"In on_write");
-            boost::ignore_unused(bytes_transferred);
-
-            if (ec)
-                return fail(ec, L"write");
-
-            _outbox.pop_front();
-            do_write_loop(); // drain _outbox
-        }
-
         void on_read(beast::error_code ec, std::size_t bytes_transferred)
         {
             VERBOSE(L"In on_read");
@@ -282,32 +335,13 @@ namespace /*anon*/ {
             const std::wstring wdata = utf8_decode(beast::buffers_to_string(buffer_.data()));
             VERBOSE(L"Received[" << bytes_transferred << L"] " << std::quoted(wdata));
 
-            if (s_on_data_cb)
-                s_on_data_cb(wdata.c_str(), wdata.length());
+            if (on_data_cb)
+                on_data_cb(handle_, wdata.c_str(), wdata.length());
 
             buffer_.consume(bytes_transferred); // some forms of async_read can read extra data
 
             VERBOSE(L"Issue new async_read in on_read");
             ws_.async_read(buffer_, beast::bind_front_handler(&Session::on_read, shared_from_this()));
-        }
-
-        /// Only called when client proactively closes connection by calling
-        /// websocket_disconnect. 
-        /// \param ec instance of error code
-        void on_close(beast::error_code ec)
-        {
-            VERBOSE(L"In on_close");
-            if (ec)
-                fail(ec, L"close");
-
-            if (s_on_disconnect_cb)
-                s_on_disconnect_cb();
-
-            get_lowest_layer(ws_).cancel(); // cause all async operations to abort
-
-            if (!Manager::Clear(shared_from_this())) {
-                // CERR(L"Could not remove active session"); // redundant message when Sessions::Install fails
-            }
         }
     };
 }
@@ -315,17 +349,23 @@ namespace /*anon*/ {
 WSDLLAPI void enable_verbose(intptr_t enabled)
 {
     COUT(L"Verbose output " << (enabled ? L"enabled" : L"disabled"));
-    s_enable_verbose = enabled;
+    g_enable_verbose = enabled;
 }
 
-WSDLLAPI size_t websocket_connect(wchar_t const* szServer)
+
+WSDLLAPI websocket_handle_t websocket_connect(wchar_t const* szServer, size_t dwOnFail, size_t dwOnDisconnect, size_t dwOnData)
 {
-    auto new_session = Manager::Install(std::make_shared<Session>());
-    if (!new_session) {
-        COUT(L"A session is already active.");
+    auto session     = std::make_shared<Session>();
+    session->handle_ = g_session_manager.Register(session);
+
+    session->on_fail_cb       = reinterpret_cast<on_fail_t>(dwOnFail);
+    session->on_disconnect_cb = reinterpret_cast<on_disconnect_t>(dwOnDisconnect);
+    session->on_data_cb       = reinterpret_cast<on_data_t>(dwOnData);
+
+    if (!g_session_manager.Active(session->handle_)) {
+        COUT(L"Session rejected"); // shouldn't happen currently
         return 0;
     }
-    assert(new_session == Manager::Active());
 
     VERBOSE(L"Connecting to the server: " << szServer);
 
@@ -341,56 +381,28 @@ WSDLLAPI size_t websocket_connect(wchar_t const* szServer)
     if (path.empty())
         path = L"/";
 
-    new_session->run(matches[1], matches[2], std::move(path));
-
-    return 1;        
+    return session->run(matches[1], matches[2], std::move(path)) ? session->handle_ : Handle{};
 }
 
-WSDLLAPI size_t websocket_disconnect()
+WSDLLAPI size_t websocket_disconnect(websocket_handle_t h)
 {
-    if (SessionPtr sess = Manager::Active()) {
-        sess->disconnect();
-        return 1;
+    if (SessionPtr sess = g_session_manager.Active(h)) {
+        return sess->disconnect();
     }
     CERR(L"Session not active. Can't disconnect.");
     return 0;
 }
 
-WSDLLAPI size_t websocket_send(wchar_t const* szMessage, size_t dwLen, bool /*TODO: isBinary*/)
+WSDLLAPI size_t websocket_send(websocket_handle_t h, wchar_t const* szMessage, size_t dwLen)
 {
-    if (SessionPtr sess = Manager::Active()) {
-        sess->send_message(std::wstring(szMessage, dwLen));
-        return 1;
+    if (SessionPtr sess = g_session_manager.Active(h)) {
+        return sess->send_message(std::wstring(szMessage, dwLen));
     }
     CERR(L"Session not active. Can't send data.");
     return 0;
 }
 
-WSDLLAPI size_t websocket_isconnected()
+WSDLLAPI size_t websocket_isconnected(websocket_handle_t h)
 {
-    return Manager::Active() != nullptr;
-}
-
-WSDLLAPI size_t websocket_register_on_fail_cb(size_t dwAddress)
-{
-    VERBOSE(L"Registering on_fail callback");
-    s_on_fail_cb = reinterpret_cast<on_fail_t>(dwAddress);
-
-    return 1;
-}
-
-WSDLLAPI size_t websocket_register_on_disconnect_cb(size_t dwAddress)
-{
-    VERBOSE(L"Registering on_disconnect callback");
-    s_on_disconnect_cb = reinterpret_cast<on_disconnect_t>(dwAddress);
-
-    return 1;
-}
-
-WSDLLAPI size_t websocket_register_on_data_cb(size_t dwAddress)
-{
-    VERBOSE(L"Registering on_data callback");
-    s_on_data_cb = reinterpret_cast<on_data_t>(dwAddress);
-
-    return 1;
+    return g_session_manager.Active(h) != nullptr;
 }

--- a/library.cpp
+++ b/library.cpp
@@ -19,7 +19,7 @@ using namespace std::chrono_literals;
 #define CERR(msg) TRACE(std::wcerr, msg)
 
 namespace /*anon*/ {
-    static on_connect_t    s_on_connect_cb{nullptr};
+    // static on_connect_t    s_on_connect_cb{nullptr};
     static on_fail_t       s_on_fail_cb{nullptr};
     static on_disconnect_t s_on_disconnect_cb{nullptr};
     static on_data_t       s_on_data_cb{nullptr};
@@ -116,7 +116,7 @@ namespace /*anon*/ {
         tcp::resolver                        resolver_{ws_.get_executor()};
 
         beast::flat_buffer buffer_;
-        std::wstring       host_, path_; // path part in url. For example: /v2/ws
+        std::wstring       host_, port_, path_; // path part in url. For example: /v2/ws
 
         /// Print error related information in stderr
         /// \param ec instance that contains error related information
@@ -140,82 +140,41 @@ namespace /*anon*/ {
       public:
         Session() = default;
 
-        /// Send message to remote websocket server
-        /// \param data to be sent
-        void send_message(std::wstring const& data)
+        short connect(wchar_t const* szServer)
         {
-            post(ws_.get_executor(),
-                 std::bind(&Session::do_send_message, shared_from_this(), utf8_encode(data)));
-        }
+            VERBOSE(L"Connecting to the server: " << szServer);
 
-        /// Close the connect between websocket client and server. It call
-        /// async_close to call a callback function which also calls user
-        /// registered callback function to deal with close event.
-        void disconnect()
-        {
-            post(ws_.get_executor(), std::bind(&Session::do_disconnect, shared_from_this()));
-        }
+            static boost::wregex const s_pat(LR"(^wss?://([\w\.]+):(\d+)(.*)$)");
 
-        /// Start the asynchronous operation
-        /// \param host host to be connected
-        /// \param port tcp port to be connected
-        void run(std::wstring host, std::wstring port, std::wstring path)
-        {
-            // Save these for later
-            host_ = std::move(host);
+            boost::wcmatch matches;
+            if (!boost::regex_match(szServer, matches, s_pat)) {
+                COUT(L"Failed to parse host & port. Correct example: ws://localhost:8080/");
+                return 0;
+            }
+
+            std::wstring path(boost::trim_copy(matches[3].str()));
+            if (path.empty())
+                path = L"/";
+
+            host_ = std::move(matches[1]);
+            port_ = std::move(matches[2]);
             path_ = std::move(path);
 
-            VERBOSE(L"Run host_: " << host_ << L", port: " << port << L", path_: " << path_);
-
-            // Look up the domain name
-            resolver_.async_resolve(utf8_encode(host_), utf8_encode(port),
-                                    beast::bind_front_handler(&Session::on_resolve, shared_from_this()));
-        }
-
-      private: // all private (do_*/on_*) assumed on strand
-        std::deque<std::string> _outbox; // NOTE: reference stability of elements
-
-        void do_send_message(std::string data)
-        {
-            VERBOSE(L"Queueing message: " << quoted(utf8_decode(data)));
-            _outbox.push_back(std::move(data)); // extend lifetime to completion of async write
-
-            if (_outbox.size()==1) // need to start write chain?
-                do_write_loop();
-        }
-
-        void do_disconnect()
-        {
-            VERBOSE(L"Disconnecting");
-            ws_.async_close(websocket::close_code::normal,
-                            beast::bind_front_handler(&Session::on_close, shared_from_this()));
-        }
-
-        /// Callback function registered by async_resolve method. It is
-        /// called after resolve operation is done. It will call
-        /// async_connect to issue async connecting operation with
-        /// callback function
-        /// \param ec
-        /// \param results
-        void on_resolve(beast::error_code ec, tcp::resolver::results_type const& results)
-        {
-            VERBOSE(L"In on_resolve");
+            boost::system::error_code ec;
+            auto const results = resolver_.resolve(utf8_encode(host_), utf8_encode(port_), ec);
             if (ec)
-                return fail(ec, L"resolve");
+            {
+                COUT(L"Failed to resolve IP address");
+                return 0;
+            }
+
+            VERBOSE(L"IP address: " << results->endpoint());
 
             // Set the timeout for the operation
             beast::get_lowest_layer(ws_).expires_after(30s);
 
             // Make the connection on the IP address we get from a lookup
-            beast::get_lowest_layer(ws_).async_connect(
-                results, beast::bind_front_handler(&Session::on_connect, shared_from_this()));
-        }
-
-        void on_connect(beast::error_code ec, tcp::resolver::results_type::endpoint_type ep)
-        {
-            VERBOSE(L"In on_connect");
-            if (ec)
-                return fail(ec, L"connect");
+            beast::get_lowest_layer(ws_).connect(results);
 
             // Turn off the timeout on the tcp_stream, because
             // the websocket stream has its own timeout system.
@@ -233,23 +192,131 @@ namespace /*anon*/ {
             // Perform the websocket handshake
 
             // Host HTTP header includes the port. See https://tools.ietf.org/html/rfc7230#section-5.4
-            ws_.async_handshake(utf8_encode(host_) + ":" + std::to_string(ep.port()), utf8_encode(path_),
-                                beast::bind_front_handler(&Session::on_handshake, shared_from_this()));
-        }
-
-        void on_handshake(beast::error_code ec)
-        {
-            VERBOSE(L"In on_handshake");
-            if (ec)
-                return fail(ec, L"handshake");
-
-            if (s_on_connect_cb)
-                s_on_connect_cb();
+            ws_.handshake(utf8_encode(host_) + ":" + utf8_encode(port_), utf8_encode(path_)); 
 
             // Send the message
             VERBOSE(L"Issue async_read in on_handshake");
             ws_.async_read(buffer_, beast::bind_front_handler(&Session::on_read, shared_from_this()));
+
+            return 1;
         }
+
+        /// Send message to remote websocket server
+        /// \param data to be sent
+        void send_message(std::wstring const& data)
+        {
+            post(ws_.get_executor(),
+                 std::bind(&Session::do_send_message, shared_from_this(), utf8_encode(data)));
+        }
+
+        /// Close the connect between websocket client and server. It call
+        /// async_close to call a callback function which also calls user
+        /// registered callback function to deal with close event.
+        void disconnect()
+        {
+            // post(ws_.get_executor(), std::bind(&Session::do_disconnect, shared_from_this()));
+            VERBOSE(L"Disconnecting");
+            get_lowest_layer(ws_).cancel(); // cause all async operations to abort
+
+            if (!Manager::Clear(shared_from_this())) {
+                // CERR(L"Could not remove active session"); // redundant message when Sessions::Install fails
+            }
+        }
+
+        /// Start the asynchronous operation
+        /// \param host host to be connected
+        /// \param port tcp port to be connected
+        // void run(std::wstring host, std::wstring port, std::wstring path)
+        // {
+        //     // Save these for later
+        //     host_ = std::move(host);
+        //     path_ = std::move(path);
+
+        //     VERBOSE(L"Run host_: " << host_ << L", port: " << port << L", path_: " << path_);
+
+        //     // Look up the domain name
+        //     resolver_.async_resolve(utf8_encode(host_), utf8_encode(port),
+        //                             beast::bind_front_handler(&Session::on_resolve, shared_from_this()));
+        // }
+
+      private: // all private (do_*/on_*) assumed on strand
+        std::deque<std::string> _outbox; // NOTE: reference stability of elements
+
+        void do_send_message(std::string data)
+        {
+            VERBOSE(L"Queueing message: " << quoted(utf8_decode(data)));
+            _outbox.push_back(std::move(data)); // extend lifetime to completion of async write
+
+            if (_outbox.size()==1) // need to start write chain?
+                do_write_loop();
+        }
+
+        // void do_disconnect()
+        // {
+        //     VERBOSE(L"Disconnecting");
+        //     ws_.async_close(websocket::close_code::normal,
+        //                     beast::bind_front_handler(&Session::on_close, shared_from_this()));
+        // }
+
+        /// Callback function registered by async_resolve method. It is
+        /// called after resolve operation is done. It will call
+        /// async_connect to issue async connecting operation with
+        /// callback function
+        /// \param ec
+        /// \param results
+        // void on_resolve(beast::error_code ec, tcp::resolver::results_type const& results)
+        // {
+        //     VERBOSE(L"In on_resolve");
+        //     if (ec)
+        //         return fail(ec, L"resolve");
+
+        //     // Set the timeout for the operation
+        //     beast::get_lowest_layer(ws_).expires_after(30s);
+
+        //     // Make the connection on the IP address we get from a lookup
+        //     beast::get_lowest_layer(ws_).async_connect(
+        //         results, beast::bind_front_handler(&Session::on_connect, shared_from_this()));
+        // }
+
+        // void on_connect(beast::error_code ec, tcp::resolver::results_type::endpoint_type ep)
+        // {
+        //     VERBOSE(L"In on_connect");
+        //     if (ec)
+        //         return fail(ec, L"connect");
+
+        //     // Turn off the timeout on the tcp_stream, because
+        //     // the websocket stream has its own timeout system.
+        //     beast::get_lowest_layer(ws_).expires_never();
+
+        //     // Set suggested timeout settings for the websocket
+        //     ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
+
+        //     // Set a decorator to change the User-Agent of the handshake
+        //     ws_.set_option(websocket::stream_base::decorator([](websocket::request_type& req) {
+        //         req.set(http::field::user_agent,
+        //                 std::string(BOOST_BEAST_VERSION_STRING) + " WsDll");
+        //     }));
+
+        //     // Perform the websocket handshake
+
+        //     // Host HTTP header includes the port. See https://tools.ietf.org/html/rfc7230#section-5.4
+        //     ws_.async_handshake(utf8_encode(host_) + ":" + std::to_string(ep.port()), utf8_encode(path_),
+        //                         beast::bind_front_handler(&Session::on_handshake, shared_from_this()));
+        // }
+
+        // void on_handshake(beast::error_code ec)
+        // {
+        //     VERBOSE(L"In on_handshake");
+        //     if (ec)
+        //         return fail(ec, L"handshake");
+
+        //     if (s_on_connect_cb)
+        //         s_on_connect_cb();
+
+        //     // Send the message
+        //     VERBOSE(L"Issue async_read in on_handshake");
+        //     ws_.async_read(buffer_, beast::bind_front_handler(&Session::on_read, shared_from_this()));
+        // }
 
         void do_write_loop()
         {
@@ -298,21 +365,21 @@ namespace /*anon*/ {
         /// Only called when client proactively closes connection by calling
         /// websocket_disconnect. 
         /// \param ec instance of error code
-        void on_close(beast::error_code ec)
-        {
-            VERBOSE(L"In on_close");
-            if (ec)
-                fail(ec, L"close");
+        // void on_close(beast::error_code ec)
+        // {
+        //     VERBOSE(L"In on_close");
+        //     if (ec)
+        //         fail(ec, L"close");
 
-            if (s_on_disconnect_cb)
-                s_on_disconnect_cb();
+        //     if (s_on_disconnect_cb)
+        //         s_on_disconnect_cb();
 
-            get_lowest_layer(ws_).cancel(); // cause all async operations to abort
+        //     get_lowest_layer(ws_).cancel(); // cause all async operations to abort
 
-            if (!Manager::Clear(shared_from_this())) {
-                // CERR(L"Could not remove active session"); // redundant message when Sessions::Install fails
-            }
-        }
+        //     if (!Manager::Clear(shared_from_this())) {
+        //         // CERR(L"Could not remove active session"); // redundant message when Sessions::Install fails
+        //     }
+        // }
     };
 }
 
@@ -331,23 +398,12 @@ WSDLLAPI size_t websocket_connect(wchar_t const* szServer)
     }
     assert(new_session == Manager::Active());
 
-    VERBOSE(L"Connecting to the server: " << szServer);
-
-    static boost::wregex const s_pat(LR"(^wss?://([\w\.]+):(\d+)(.*)$)");
-
-    boost::wcmatch matches;
-    if (!boost::regex_match(szServer, matches, s_pat)) {
-        COUT(L"Failed to parse host & port. Correct example: ws://localhost:8080/");
+    if (!new_session->connect(szServer))
+    {
+        COUT(L"Connect attempt failed.");
         return 0;
     }
-
-    std::wstring path(boost::trim_copy(matches[3].str()));
-    if (path.empty())
-        path = L"/";
-
-    new_session->run(matches[1], matches[2], std::move(path));
-
-    return 1;
+    return 1;        
 }
 
 WSDLLAPI size_t websocket_disconnect()
@@ -375,13 +431,13 @@ WSDLLAPI size_t websocket_isconnected()
     return Manager::Active() != nullptr;
 }
 
-WSDLLAPI size_t websocket_register_on_connect_cb(size_t dwAddress)
-{
-    VERBOSE(L"Registering on_connect callback");
-    s_on_connect_cb = reinterpret_cast<on_connect_t>(dwAddress);
+// WSDLLAPI size_t websocket_register_on_connect_cb(size_t dwAddress)
+// {
+//     VERBOSE(L"Registering on_connect callback");
+//     s_on_connect_cb = reinterpret_cast<on_connect_t>(dwAddress);
 
-    return 1;
-}
+//     return 1;
+// }
 
 WSDLLAPI size_t websocket_register_on_fail_cb(size_t dwAddress)
 {

--- a/library.h
+++ b/library.h
@@ -24,7 +24,7 @@
 
 #include <cstddef>
 extern "C" {
-    typedef void (*on_connect_t)();
+    // typedef void (*on_connect_t)();
     typedef void (*on_fail_t)(wchar_t const* from);
     typedef void (*on_disconnect_t)();
     typedef void (*on_data_t)(wchar_t const*, size_t);

--- a/library.h
+++ b/library.h
@@ -24,19 +24,18 @@
 
 #include <cstddef>
 extern "C" {
-    typedef void (*on_fail_t)(wchar_t const* from);
-    typedef void (*on_disconnect_t)();
-    typedef void (*on_data_t)(wchar_t const*, size_t);
+    typedef intptr_t websocket_handle_t;
+    typedef void (*on_fail_t)(websocket_handle_t, wchar_t const* from);
+    typedef void (*on_disconnect_t)(websocket_handle_t);
+    typedef void (*on_data_t)(websocket_handle_t, wchar_t const*, size_t);
+
+    WSDLLAPI websocket_handle_t websocket_connect(wchar_t const* szServer, size_t dwOnFail,
+                                                  size_t dwOnDisconnect, size_t dwOnData);
 
     WSDLLAPI void   enable_verbose(intptr_t enabled);
-    WSDLLAPI size_t websocket_connect(wchar_t const* szServer);
-    WSDLLAPI size_t websocket_disconnect();
-    WSDLLAPI size_t websocket_send(wchar_t const* szMessage, size_t dwLen, bool isBinary);
-    WSDLLAPI size_t websocket_isconnected();
-
-    WSDLLAPI size_t websocket_register_on_fail_cb(size_t dwAddress);
-    WSDLLAPI size_t websocket_register_on_disconnect_cb(size_t dwAddress);
-    WSDLLAPI size_t websocket_register_on_data_cb(size_t dwAddress);
+    WSDLLAPI size_t websocket_disconnect(websocket_handle_t);
+    WSDLLAPI size_t websocket_send(websocket_handle_t, wchar_t const* szMessage, size_t dwLen);
+    WSDLLAPI size_t websocket_isconnected(websocket_handle_t);
 }
 
 #endif // WebSocketAsio_LIBRARY_H

--- a/library.h
+++ b/library.h
@@ -24,7 +24,6 @@
 
 #include <cstddef>
 extern "C" {
-    // typedef void (*on_connect_t)();
     typedef void (*on_fail_t)(wchar_t const* from);
     typedef void (*on_disconnect_t)();
     typedef void (*on_data_t)(wchar_t const*, size_t);
@@ -35,7 +34,6 @@ extern "C" {
     WSDLLAPI size_t websocket_send(wchar_t const* szMessage, size_t dwLen, bool isBinary);
     WSDLLAPI size_t websocket_isconnected();
 
-    WSDLLAPI size_t websocket_register_on_connect_cb(size_t dwAddress);
     WSDLLAPI size_t websocket_register_on_fail_cb(size_t dwAddress);
     WSDLLAPI size_t websocket_register_on_disconnect_cb(size_t dwAddress);
     WSDLLAPI size_t websocket_register_on_data_cb(size_t dwAddress);


### PR DESCRIPTION
Here's my edit on top of g9c3476 to show the interface as sketched in the synopsis on https://github.com/Danp2/WebSocketAsio/issues/9

I did **NOT** adapt the AHK/AutoIt scripts as I don't know enough about those script languages. However, you can probably trivially adapt, like I did in https://github.com/Danp2/WebSocketAsio/pull/11/files#diff-0279b7052b5595cd1c9558eb9a7f57a92f4b7d22dc75a53a3536ae6ec9879863R53

Note how making the end-user interface largely synchronous does *not* imply using synchronous implementation. In fact, as long as you want asynchronous closing/read operation you *cannot* because [sync and async don't mix](https://github.com/Danp2/WebSocketAsio/pull/10#discussion_r1174679994)

Since you seemed to have hinted that AutoIt simply cannot afford async callbacks without undefined behavior, I'd consider moving to a fully sync approach. But I cannot judge whether (a) this suits your needs (b) what you would like the interface to look like.